### PR TITLE
Explicitly label the `useAddressSelection` button

### DIFF
--- a/src/app/components/poi-location-editor/poi-location-editor.html
+++ b/src/app/components/poi-location-editor/poi-location-editor.html
@@ -14,7 +14,7 @@
     {{suggestedAddress.StateOrProvince}}
     {{suggestedAddress.Postcode}}
     <br>
-    <ion-button size="small" (click)="useAddressSelection()">Use This Address <ion-icon slot="end" name="copy"></ion-icon></ion-button>
+    <ion-button size="small" (click)="useAddressSelection()">Use this address to fill the form below <ion-icon slot="end" name="copy"></ion-icon></ion-button>
   </p>
 </ion-note>
 

--- a/src/app/components/poi-location-editor/poi-location-editor.html
+++ b/src/app/components/poi-location-editor/poi-location-editor.html
@@ -14,7 +14,7 @@
     {{suggestedAddress.StateOrProvince}}
     {{suggestedAddress.Postcode}}
     <br>
-    <ion-button size="small" (click)="useAddressSelection()">Use this address to fill the form below <ion-icon slot="end" name="copy"></ion-icon></ion-button>
+    <ion-button size="small" (click)="useAddressSelection()">Use this address below <ion-icon slot="end" name="copy"></ion-icon></ion-button>
   </p>
 </ion-note>
 


### PR DESCRIPTION
When adding a new location, it’s not very clear what clicking the `USE THIS LOCATION` button will do.