### PR TITLE
Adds a delete action for POI photos, restricted to the original uploa…

### DIFF
--- a/src/app/components/poi-details/poi-details.html
+++ b/src/app/components/poi-details/poi-details.html
@@ -356,9 +356,14 @@
             <span *ngIf="item.User">{{item.User.Username}}</span>
             <span *ngIf="!item.User">{{item.Username}}</span>
           </ion-label>
-          <ion-label slot="end">
+          <ion-note slot="end">
             {{item.DateCreated | date }}
-          </ion-label>
+          </ion-note>
+          <ion-buttons slot="end" *ngIf="canDeleteMediaItem(item)">
+            <ion-button fill="clear" color="danger" title="Delete photo" (click)="confirmDeleteMediaItem(item)">
+              <ion-icon name="trash" slot="icon-only"></ion-icon>
+            </ion-button>
+          </ion-buttons>
         </ion-item>
 
         <ion-card-content>

--- a/src/app/model/CoreDataModel.ts
+++ b/src/app/model/CoreDataModel.ts
@@ -220,6 +220,7 @@ export interface MediaItem {
 }
 
 export interface UserProfile {
+    ID?: number;
     Username: string;
     EmailAddress: string;
     Profile: string;

--- a/src/app/services/APIClient.ts
+++ b/src/app/services/APIClient.ts
@@ -217,7 +217,12 @@ export class APIClient {
     return this.http.post(this.serviceBaseURL + '/poi/', jsonString, this.getHttpRequestOptions())
       .toPromise();
   }
+  deleteMediaItem(mediaItemId: number): Promise<any> {
+    const serviceURL = `${environment.apiBase}/v4/profile/mediaitem/${mediaItemId}`;
 
+    return this.http.delete(serviceURL, this.getHttpRequestOptions())
+      .toPromise();
+  }
   getPanoramioLocationPhotos(pos: GeoLatLng): Promise<any> {
     //
     return new Promise(resolve => {


### PR DESCRIPTION
The delete action is only shown to the original uploader (ID-based ownership check) and uses a confirmation dialog before performing the delete. 
UI refresh re-fetches POI from server; if POIs are served from Mongo cache, immediate visibility of delete depends on cache invalidation/worker sync. Follow-up may be required to refresh/invalidate POI cache on delete

Related to https://github.com/openchargemap/ocm-system/issues/218

