### PR TITLE
Add tri-state POI filters (photos/comments/check-ins)

### DIFF
--- a/src/app/model/POISearchParams.ts
+++ b/src/app/model/POISearchParams.ts
@@ -21,6 +21,9 @@ export class POISearchParams {
     public maxPowerKW: number = null;
 
     public submissionStatusTypeIdList: Array<number> = null;
+    public hasmedia: 'true' | 'false' | null = null;
+    public hascomment: 'true' | 'false' | null = null;
+    public hascheckins: 'true' | 'false' | null = null;
 
     public maxResults: number = 500;
     public additionalParams: string = null;

--- a/src/app/model/SearchSettings.ts
+++ b/src/app/model/SearchSettings.ts
@@ -2,7 +2,7 @@ import { GeoLatLng } from "./GeoPosition";
 import { MapType } from "../services/mapping/interfaces/mapping";
 
 export const MAX_POWER: number = 1000;
-
+export type TriStateBooleanFilter = 'any' | 'true' | 'false';
 export class SearchSettings {
   OperatorList: Array<number>;
   ConnectionTypeList: Array<number>;
@@ -22,6 +22,9 @@ export class SearchSettings {
   EnableAdvancedEditorFeatures: boolean;
   EnablePOIPendingApproval: boolean;
   MaxResults: number;
+  HasMedia: TriStateBooleanFilter;
+  HasComment: TriStateBooleanFilter;
+  HasCheckins: TriStateBooleanFilter;
 
   constructor() {
     this.OperatorList = [];
@@ -39,6 +42,9 @@ export class SearchSettings {
     this.EnableAdvancedEditorFeatures = false;
     this.EnablePOIPendingApproval = false;
     this.MaxResults = 500;
+    this.HasMedia = 'any';
+    this.HasComment = 'any';
+    this.HasCheckins = 'any';
   }
 
   public LoadSettings() { }
@@ -53,6 +59,9 @@ export class SearchSettings {
     this.StatusTypeList = [];
     this.MinPowerKW = null;
     this.MaxPowerKW = null;
+    this.HasMedia = 'any';
+    this.HasComment = 'any';
+    this.HasCheckins = 'any';
   }
 
   public CheckForActiveFilters(): boolean {
@@ -64,7 +73,10 @@ export class SearchSettings {
       this.StatusTypeList.length > 0 ||
       this.MinPowerKW > 0 ||
       this.MaxPowerKW > 0 ||
-      (this.MaxPowerKW != null && this.MaxPowerKW < MAX_POWER)
+      (this.MaxPowerKW != null && this.MaxPowerKW < MAX_POWER) ||
+      this.HasMedia !== 'any' ||
+      this.HasComment !== 'any' ||
+      this.HasCheckins !== 'any'
     ) {
       this.HasActiveFilters = true;
     } else {

--- a/src/app/pages/search/search.ts
+++ b/src/app/pages/search/search.ts
@@ -6,6 +6,7 @@ import { RoutePlannerPage } from './../route-planner/route-planner';
 import { POIDetailsPage } from './../poi-details/poi-details';
 import { GeoLatLng, GeoPosition } from './../../model/GeoPosition';
 import { POISearchParams } from './../../model/POISearchParams';
+import { TriStateBooleanFilter } from './../../model/SearchSettings';
 import { Utils } from './../../core/Utils';
 import { Logging, LogLevel } from './../../services/Logging';
 import { JourneyManager } from './../../services/JourneyManager';
@@ -264,7 +265,14 @@ export class SearchPage implements OnInit, AfterViewInit {
     }
     return null;
   }
+   private applyTriStatePOIFilter(value: TriStateBooleanFilter, params: POISearchParams, fieldName: 'hasmedia' | 'hascomment' | 'hascheckins'): boolean {
+    if (value === 'true' || value === 'false') {
+      params[fieldName] = value;
+      return true;
+    }
 
+    return false;
+  }
 
   async refreshMapResults() {
     if (!this.searchOnDemand) {
@@ -360,6 +368,9 @@ export class SearchPage implements OnInit, AfterViewInit {
       if (this.appManager.searchSettings.MaxResults != null && this.appManager.searchSettings.MaxResults > 0 && this.appManager.searchSettings.MaxResults <= 10000) {
         params.maxResults = this.appManager.searchSettings.MaxResults;
       }
+      this.applyTriStatePOIFilter(this.appManager.searchSettings.HasMedia, params, 'hasmedia');
+      this.applyTriStatePOIFilter(this.appManager.searchSettings.HasComment, params, 'hascomment');
+      this.applyTriStatePOIFilter(this.appManager.searchSettings.HasCheckins, params, 'hascheckins');
 
       if (this.journeyManager.getRoutePolyline() != null) {
         // when searching along a polyline we discard any other bounding box filters etc

--- a/src/app/pages/settings/settings.html
+++ b/src/app/pages/settings/settings.html
@@ -58,6 +58,23 @@
           }}</ion-select-option>
       </ion-select>
     </ion-item>
+     <ion-item>
+      <ion-select [label]="'ocm.search.photos' | translate" [(ngModel)]="searchSettings.HasMedia" multiple="false" (ionChange)="onTriStateFilterChange()" cancelText="Cancel" okText="OK">
+        <ion-select-option *ngFor="let option of triStateFilterOptions" [value]="option.value">{{option.titleKey | translate}}</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-select [label]="'ocm.search.comments' | translate" [(ngModel)]="searchSettings.HasComment" multiple="false" (ionChange)="onTriStateFilterChange()" cancelText="Cancel" okText="OK">
+        <ion-select-option *ngFor="let option of triStateFilterOptions" [value]="option.value">{{option.titleKey | translate}}</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-select [label]="'ocm.search.checkins' | translate" [(ngModel)]="searchSettings.HasCheckins" multiple="false" (ionChange)="onTriStateFilterChange()" cancelText="Cancel" okText="OK">
+        <ion-select-option *ngFor="let option of triStateFilterOptions" [value]="option.value">{{option.titleKey | translate}}</ion-select-option>
+      </ion-select>
+    </ion-item>
     <ion-item>
       <ion-range label-placement="start" label="Power (kW)" dualKnobs="true" pin="true" [(ngModel)]="powerRange" [ticks]="false" [snaps]="false" [min]="0" [max]="maxPower">
         <ion-icon slot="start" size="small" name="flash">0</ion-icon>

--- a/src/app/pages/settings/settings.ts
+++ b/src/app/pages/settings/settings.ts
@@ -18,7 +18,11 @@ export class SettingsPage implements OnInit {
   maxPower = MAX_POWER;
 
   public powerRange = { lower: 0, upper: this.maxPower ?? 500 };
-
+   public triStateFilterOptions = [
+    { value: 'any', titleKey: 'ocm.search.any' },
+    { value: 'true', titleKey: 'ocm.search.yes' },
+    { value: 'false', titleKey: 'ocm.search.no' }
+  ];
   constructor(
     public appManager: AppManager,
     public poiManager: POIManager,
@@ -49,6 +53,10 @@ export class SettingsPage implements OnInit {
     } else {
       return false;
     }
+  }
+  
+  onTriStateFilterChange() {
+    this.searchSettings.CheckForActiveFilters();
   }
 
   clearFilters() {

--- a/src/app/services/APIClient.ts
+++ b/src/app/services/APIClient.ts
@@ -65,6 +65,9 @@ export class APIClient {
     if (params.distance != null) serviceParams += '&distance=' + params.distance;
     if (params.distanceUnit != null) serviceParams += '&distanceunit=' + params.distanceUnit;
     if (params.includeComments != null) serviceParams += '&includecomments=' + params.includeComments;
+    if (params.hasmedia != null) serviceParams += '&hasmedia=' + params.hasmedia;
+    if (params.hascomment != null) serviceParams += '&hascomment=' + params.hascomment;
+    if (params.hascheckins != null) serviceParams += '&hascheckins=' + params.hascheckins;
     if (params.maxResults != null) serviceParams += '&maxresults=' + params.maxResults;
     if (params.countryIdList != null) serviceParams += '&countryid=' + this.getNumberListString(params.countryIdList);
     if (params.levelIdList != null) serviceParams += '&levelid=' + this.getNumberListString(params.levelIdList);

--- a/src/app/services/AppManager.ts
+++ b/src/app/services/AppManager.ts
@@ -9,6 +9,7 @@ import { Platform, ToastController, LoadingController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
 
 import { UserProfile, SubmissionType, SearchSettings, Journey, WayPoint, GeoLatLng, Language } from '../model/AppModels';
+import { TriStateBooleanFilter } from '../model/SearchSettings';
 import { SubmissionQueue } from './SubmissionQueue';
 import { ReferenceDataManager } from './ReferenceDataManager';
 import { JourneyManager } from './JourneyManager';
@@ -85,7 +86,23 @@ export class AppManager {
     // this.journeyManager.setupTestJourneys();
     this.journeyManager.loadJourneys();
   }
+   private normalizeTriStateFilter(value: any): TriStateBooleanFilter {
+        if (value === true || value === 'true') {
+          return 'true';
+        }
 
+        if (value === false || value === 'false') {
+          return 'false';
+        }
+
+        return 'any';
+  }
+
+  private ensureFilterDefaults() {
+    this.searchSettings.HasMedia = this.normalizeTriStateFilter(this.searchSettings.HasMedia);
+    this.searchSettings.HasComment = this.normalizeTriStateFilter(this.searchSettings.HasComment);
+    this.searchSettings.HasCheckins = this.normalizeTriStateFilter(this.searchSettings.HasCheckins);
+  }
   /**
    * Load search filter settings from local storage
    */
@@ -97,10 +114,12 @@ export class AppManager {
 
         // clone settings into SearchSettings instance
         Object.assign(this.searchSettings, settings);
+        this.ensureFilterDefaults();
       } catch (ex) {
         // failed to load settings
       }
     }
+      this.ensureFilterDefaults();
   }
 
   savePushRegistration(token: string) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -102,7 +102,14 @@
       "usageTypes": "Usage",
       "operationalStatusTypes": "Status",
       "performSearch": "Search",
-      "progress": "Searching.."
+      "progress": "Searching..",
+      "photos": "Photos",
+      "comments": "Comments",
+      "checkins": "Check-ins",
+      "any": "Any",
+      "yes": "Yes",
+      "no": "No"
+
     },
     "navigation": {
       "home": "Home",


### PR DESCRIPTION
Related to https://github.com/openchargemap/ocm-app/issues/16

This PR adds tri-state filtering support in the Ionic App for POI search results by:

Photos (hasmedia)

Comments (hascomment)

Check-ins (hascheckins)

The filters are exposed in Settings via simple Any / Yes / No controls and are mapped to the API as query parameters only when explicitly selected (true / false).

When set to Any, the parameters are omitted entirely, preserving existing default search behavior.

This PR does not modify API logic — it only wires the new filters into the app search flow and request construction.