### PR TITLE
Add batch photo upload flow with review modal, per-image rotation, and client-side image processing

### DIFF
--- a/src/app/pages/mediaupload/mediaupload.html
+++ b/src/app/pages/mediaupload/mediaupload.html
@@ -17,15 +17,15 @@
     </p>
 
     <div class="upload">
-      <ion-button (click)="inputFile.click()">
+        <ion-button (click)="onChoosePhoto()">
         <ion-icon name="camera" aria-label="camera" slot="start"></ion-icon>
         <ion-label>Choose Photo..</ion-label>
       </ion-button>
-      <input type="file" #inputFile required id="img-upload-media" (change)="loadCameraOrLibraryImage()"/>
+       <input type="file" #inputFile required accept="image/*" multiple (change)="onFileSelectionChanged($event)"/>
     </div>
 
-    <canvas id="img-upload-canvas" style="display:none;width:500;height:500;border:1px solid red;"></canvas>
-    <ion-card *ngIf="imgData!=null">
+    <canvas #processingCanvas style="display:none;width:500;height:500;border:1px solid red;"></canvas>
+    <ion-card *ngIf="imgData!=null && !isBatchReviewOpen">
       <ion-toolbar>
         <ion-title slot="start">Preview</ion-title>
         <ion-buttons slot="end">
@@ -48,13 +48,65 @@
           </ion-item>
 
         </ion-list>
-        <img id="preview" style="max-width:500px"/>
+        <img [src]="imgData" style="max-width:500px"/>
       </ion-card-content>
     </ion-card>
 
   </div>
 
 </ion-content>
+<ion-modal #batchReviewModal [isOpen]="isBatchReviewOpen" [canDismiss]="!isBatchUploading" (didDismiss)="onBatchReviewDidDismiss()">
+  <ng-template>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Review Photos</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content>
+      <ion-list>
+        <ion-item *ngFor="let item of batchItems; trackBy: trackByItemId">
+          <ion-thumbnail slot="start" class="batch-thumb">
+            <img [src]="item.previewUrl" alt="Selected upload preview" />
+          </ion-thumbnail>
+          <ion-label>
+            <h3>{{item.file.name}}</h3>
+            <p>{{(item.sizeBytes / 1024 / 1024).toFixed(2)}} MB · Rotation {{item.rotationDeg}}°</p>
+            <p *ngIf="item.uploadStatus === 'failed'" class="upload-error">Failed: {{item.lastError || 'Upload failed'}}</p>
+            <p *ngIf="item.uploadStatus === 'uploaded'" class="upload-success">Uploaded</p>
+            <ion-input label="Comment" label-placement="stacked" type="text" placeholder="(optional comment)" [(ngModel)]="item.comment" [disabled]="isBatchUploading"></ion-input>
+            <div class="batch-actions">
+              <ion-button size="small" (click)="rotateBatchItem(item)" [disabled]="isBatchUploading || item.uploadStatus === 'uploading'">
+                <ion-icon name="refresh" slot="start"></ion-icon>
+                Rotate
+              </ion-button>
+              <ion-button size="small" color="danger" (click)="removeBatchItem(item.id)" [disabled]="isBatchUploading || item.uploadStatus === 'uploading'">
+                <ion-icon name="trash" slot="start"></ion-icon>
+                Remove
+              </ion-button>
+            </div>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+
+    <ion-footer>
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-button (click)="requestBatchReviewClose()" [disabled]="isBatchUploading">Cancel</ion-button>
+        </ion-buttons>
+        <ion-buttons slot="end">
+          <ion-button (click)="uploadBatchItems(false)" [disabled]="isBatchUploading || !hasBatchPendingUploads">
+            Upload
+          </ion-button>
+          <ion-button color="warning" *ngIf="failedCount > 0" (click)="uploadBatchItems(true)" [disabled]="isBatchUploading">
+            Retry failed ({{failedCount}})
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-footer>
+  </ng-template>
+</ion-modal>
 <ion-footer>
   <ion-toolbar>
     <ion-buttons slot="secondary">
@@ -64,7 +116,7 @@
       </ion-button>
     </ion-buttons>
     <ion-buttons slot="primary">
-      <ion-button (click)="performUpload()">
+  <ion-button (click)="performUpload()" [disabled]="isBatchReviewOpen">
         Upload
         <ion-icon name="send" slot="end"></ion-icon>
       </ion-button>

--- a/src/app/pages/mediaupload/mediaupload.scss
+++ b/src/app/pages/mediaupload/mediaupload.scss
@@ -2,3 +2,21 @@
   position: fixed;
   top: -1000px;
 }
+
+.batch-thumb {
+  --size: 72px;
+}
+
+.batch-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.upload-error {
+  color: var(--ion-color-danger, #b00020);
+}
+
+.upload-success {
+  color: var(--ion-color-success, #2dd36f);
+}

--- a/src/app/pages/mediaupload/mediaupload.ts
+++ b/src/app/pages/mediaupload/mediaupload.ts
@@ -1,24 +1,58 @@
 import { AppManager } from './../../services/AppManager';
-import { Component } from '@angular/core';
+import { Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { NavController, NavParams, ModalController } from '@ionic/angular';
 import { Logging, LogLevel } from '../../services/Logging';
+
+type UploadStatus = 'ready' | 'uploading' | 'uploaded' | 'failed';
+type ItemProcessState = 'idle' | 'processing' | 'rotating' | 'error';
+
+interface UploadReviewItem {
+    id: string;
+    file: File;
+    previewUrl: string;
+    comment: string;
+    rotationDeg: 0 | 90 | 180 | 270;
+    uploadStatus: UploadStatus;
+    processState: ItemProcessState;
+    lastError?: string;
+    sizeBytes: number;
+    width?: number;
+    height?: number;
+}
 
 @Component({
     templateUrl: 'mediaupload.html',
     styleUrls: ['./mediaupload.scss'],
     standalone: false
 })
-export class MediaUploadPage {
+export class MediaUploadPage implements OnDestroy {
+
+    readonly maxBatchFiles = 10;
+    readonly maxFileSizeBytes = 12 * 1024 * 1024;
+    readonly maxImageLongEdgePx = 1600;
+    readonly uploadJpegQuality = 0.78;
 
     mode: string;
-    processingQuality: number;
-    imgData: any;
-    targetWidth: number;
-    targetHeight: number;
-
+    imgData: string | null;
     comment: string;
     chargePointId: number;
     poi: any;
+
+    singleSelectedFile: File | null;
+    singleRotationDeg: 0 | 90 | 180 | 270;
+
+    isBatchReviewOpen: boolean;
+    batchItems: UploadReviewItem[];
+    isBatchUploading: boolean;
+
+    private processingQueue: Promise<unknown> = Promise.resolve();
+
+    @ViewChild('inputFile', { static: true })
+    inputFileRef: ElementRef<HTMLInputElement>;
+
+    @ViewChild('processingCanvas', { static: true })
+    processingCanvasRef: ElementRef<HTMLCanvasElement>;
+
 
     constructor(
         public navParams: NavParams,
@@ -27,175 +61,74 @@ export class MediaUploadPage {
         private modalController: ModalController,
         public logging: Logging
     ) {
-
-        this.processingQuality = 0.8;
-        this.targetWidth = 1024;
-        this.targetHeight = 800;
         this.mode = appManager.platformMode;
-
-
         this.chargePointId = this.navParams.get('id');
         this.poi = this.navParams.get('poi');
+
+        this.imgData = null;
         this.comment = '';
+        this.singleSelectedFile = null;
+        this.singleRotationDeg = 0;
+
+        this.isBatchReviewOpen = false;
+        this.batchItems = [];
+        this.isBatchUploading = false;
     }
 
-    processNativeImageSource(imageData) {
-        // imageData is either a base64 encoded string or a file URI
-        // If it's base64:
-        // let base64Image = 'data:image/jpeg;base64,' + imageData;
-
-        let imgUrl = imageData; // this.webview.convertFileSrc(imageData);
-        // this.logging.log("img load:" + imgUrl);
-        const canvas = <HTMLCanvasElement>document.getElementById('img-upload-canvas');
-        const ctx = canvas.getContext('2d');
-
-        // draw source image into the off-screen canvas to get base64 version
-
-        const img = new Image();
-
-        img.onload = () => {
-            this.logging.log("img load:" + img.width);
-
-            canvas.width = img.width;
-            canvas.height = img.height;
-
-            // TODO: resize source image before upload
-            ctx.fillStyle = 'rgb(0,0,0)';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-
-            this.imgData = canvas.toDataURL('image/png');
-            this.processImage();
-        };
-
-        // initiate image load
-        img.src = imgUrl;
+    ngOnDestroy(): void {
+        this.cleanupBatchState();
     }
 
-    loadCameraOrLibraryImage(fromImageLibrary: boolean = false) {
+    onChoosePhoto(): void {
+        this.inputFileRef?.nativeElement?.click();
+    }
 
-        /*
-                if (!this.isBrowserMode()) {
-                    this.logging.log("Native mode: fetching image");
+    async onFileSelectionChanged(event: Event): Promise<void> {
+        const target = event.target as HTMLInputElement;
+        const files = Array.from(target.files || []);
 
-                    if (fromImageLibrary) {
-                        this.camera.getPicture({ targetWidth: this.targetWidth, sourceType: this.camera.PictureSourceType.PHOTOLIBRARY }).then((imageData) => {
+        if (!files.length) {
+            this.resetFileInput();
+            return;
+        }
 
-                            this.processNativeImageSource(imageData);
+        const { validFiles, messages } = this.validateSelection(files);
+        for (const message of messages) {
+            await this.appManager.showToastNotification(message);
+        }
 
-                        }, (err) => {
-                            this.logging.log("Error processing getPicture (library):" + err, LogLevel.ERROR);
-                        });
-                    } else {
-                        this.camera.getPicture({ targetWidth: this.targetWidth, sourceType: this.camera.PictureSourceType.CAMERA }).then((imageData) => {
-                            this.processNativeImageSource(imageData);
-                        }, (err) => {
-                            this.logging.log("Error processing getPicture (camera):" + err, LogLevel.ERROR);
-                        });
-                    }
-                }
-        */
+        if (!validFiles.length) {
+            this.resetFileInput();
+            return;
+        }
 
+        if (validFiles.length === 1) {
+            await this.activateSingleFile(validFiles[0]);
+        } else {
+            this.activateBatchFiles(validFiles);
+        }
 
-        this.logging.log("PWA mode: fetching image");
-
-        const reader = new FileReader();
-
-        reader.onload = () => {
-            this.imgData = reader.result;
-            this.processImage();
-        };
-
-        reader.onerror = () => {
-            // alert('reader error');
-        };
-
-        // read data from file input, this will then fire the onload event
-        reader.readAsDataURL((<any>document.getElementById('img-upload-media')).files[0]);
-
-
+        this.resetFileInput();
     }
 
     isBrowserMode(): boolean {
         return (this.appManager.isPlatform('desktop') || this.appManager.isPlatform('hybrid'));
     }
 
-    processImage() {
-        const _appContext = this;
-        if (this.imgData != null) {
-
-            //  this.logging.log("processImage: " + this.imgData);
-
-            // create an off-screen canvas
-            const canvas = <HTMLCanvasElement>document.getElementById('img-upload-canvas');
-            const ctx = canvas.getContext('2d');
-
-            // set its dimension to target size
-
-            // draw source image into the off-screen canvas:
-            // ctx.drawImage(this.img, 0, 0, this.targetWidth, this.targetHeight);
-
-            const img = new Image();
-
-            img.onload = () => {
-                canvas.width = img.width;
-                canvas.height = img.height;
-                ctx.fillStyle = 'rgb(0,0,0)';
-                ctx.fillRect(0, 0, canvas.width, canvas.height);
-                ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-                this.refreshImageFromCanvas();
-            };
-
-            img.src = this.imgData;
-
-        } else {
-            this.logging.log("processImage: nothing to process.");
+    async rotateImage(): Promise<void> {
+        if (!this.singleSelectedFile) {
+            return;
         }
-    }
 
-    refreshImageFromCanvas() {
-        const canvas = <HTMLCanvasElement>document.getElementById('img-upload-canvas');
-        // encode image to data-uri with base64 version of compressed image
-        this.imgData = canvas.toDataURL('image/jpeg', 0.8);
-
-        // now ready to upload
-        (<HTMLImageElement>document.getElementById('preview')).src = this.imgData;
-    }
-
-    rotateImage() {
-        // inspired by:http://jsfiddle.net/gfcarv/t4YX4/
-        const canvas = <HTMLCanvasElement>document.getElementById('img-upload-canvas');
-
-        // store current data to an image
-        let rotatedImage = new Image();
-        rotatedImage.src = canvas.toDataURL();
-
-        rotatedImage.onload = () => {
-            // reset the canvas with new dimensions
-            let origHeight = canvas.height;
-            let origWidth = canvas.width;
-            canvas.width = origHeight;
-            canvas.height = origWidth;
-
-            origHeight = canvas.height;
-            origWidth = canvas.width;
-
-            const ctx = canvas.getContext('2d');
-            ctx.save();
-
-            ctx.translate(origWidth, origHeight / origWidth);
-            ctx.rotate(Math.PI / 2);
-
-            ctx.drawImage(rotatedImage, 0, 0);
-            ctx.restore();
-
-            rotatedImage = null;
-
-            this.refreshImageFromCanvas();
-        };
+        this.singleRotationDeg = this.nextRotation(this.singleRotationDeg);
+        await this.refreshSinglePreview();
     }
 
     async performUpload() {
+        if (this.isBatchReviewOpen && this.batchItems.length > 0) {
+            await this.uploadBatchItems(false);
+            return;
+        }
 
         if (!this.imgData) {
             await this.appManager.showToastNotification('Select an image to upload.');
@@ -211,27 +144,369 @@ export class MediaUploadPage {
         await this.appManager.showLoadingProgress('Uploading photo..');
 
         try {
-            let uploadResult = await this.appManager.submitMediaItem(submission);
-
+            await this.appManager.submitMediaItem(submission);
 
             this.appManager.dismissLoadingProgress().then(() => {
                 this.appManager.showToastNotification('Upload completed');
-
                 this.modalController.dismiss();
             });
 
-            this.appManager.analytics.appEvent("MediaUpload", "Completed");
-            // TODO: refresh this POI in background to see results with upload
+            this.appManager.analytics.appEvent('MediaUpload', 'Completed');
         } catch (rejected) {
             await this.appManager.dismissLoadingProgress();
             await this.appManager.showToastNotification('Upload failed, please try again.');
-            this.appManager.analytics.appEvent("MediaUpload", "Failed");
+            this.appManager.analytics.appEvent('MediaUpload', 'Failed');
+        }
+    }
 
+    async uploadBatchItems(retryOnlyFailed: boolean): Promise<void> {
+        const targetItems = this.batchItems.filter((item) => {
+            if (retryOnlyFailed) {
+                return item.uploadStatus === 'failed';
+            }
+            return item.uploadStatus === 'ready' || item.uploadStatus === 'failed';
+        });
+
+        if (!targetItems.length) {
+            await this.appManager.showToastNotification('No photos pending upload.');
+            return;
         }
 
+        this.isBatchUploading = true;
+
+        for (const item of targetItems) {
+            item.uploadStatus = 'uploading';
+            item.processState = 'processing';
+            item.lastError = undefined;
+
+            try {
+                const base64Image = await this.generateUploadDataForItem(item);
+                await this.appManager.submitMediaItem({
+                    chargePointID: this.chargePointId,
+                    comment: item.comment,
+                    imageDataBase64: base64Image
+                });
+
+                item.uploadStatus = 'uploaded';
+                item.processState = 'idle';
+            } catch (error: any) {
+                item.uploadStatus = 'failed';
+                item.processState = 'error';
+                item.lastError = error?.message || 'Upload failed';
+                this.logging.log(`Batch upload failed for ${item.file.name}: ${item.lastError}`, LogLevel.ERROR);
+            }
+        }
+
+        this.isBatchUploading = false;
+
+        if (this.failedCount > 0) {
+            await this.appManager.showToastNotification(`Upload finished with ${this.failedCount} failed photo(s).`);
+            return;
+        }
+
+        await this.appManager.showToastNotification('Upload completed');
+        await this.modalController.dismiss();
+    }
+
+    async rotateBatchItem(item: UploadReviewItem): Promise<void> {
+        if (this.isBatchUploading || item.uploadStatus === 'uploading') {
+            return;
+        }
+
+        const previousRotation = item.rotationDeg;
+        item.rotationDeg = this.nextRotation(item.rotationDeg);
+        item.processState = 'rotating';
+        item.lastError = undefined;
+
+        try {
+            const nextPreviewUrl = await this.generatePreviewUrlForItem(item);
+            const oldPreviewUrl = item.previewUrl;
+            item.previewUrl = nextPreviewUrl;
+            URL.revokeObjectURL(oldPreviewUrl);
+
+            item.processState = 'idle';
+        } catch (error: any) {
+            item.rotationDeg = previousRotation;
+            item.processState = 'error';
+            item.lastError = error?.message || 'Failed to rotate preview';
+        }
+    }
+
+    removeBatchItem(itemId: string): void {
+        if (this.isBatchUploading) {
+            return;
+        }
+
+        const idx = this.batchItems.findIndex((item) => item.id === itemId);
+        if (idx < 0) {
+            return;
+        }
+
+        URL.revokeObjectURL(this.batchItems[idx].previewUrl);
+        this.batchItems.splice(idx, 1);
+
+        if (this.batchItems.length === 0) {
+            this.requestBatchReviewClose();
+        }
+    }
+
+    requestBatchReviewClose(): void {
+        if (this.isBatchUploading) {
+            return;
+        }
+
+        this.isBatchReviewOpen = false;
+    }
+
+    onBatchReviewDidDismiss(): void {
+        this.cleanupBatchState();
+        this.resetFileInput();
     }
 
     async cancel() {
+        this.cleanupSingleState();
+        this.cleanupBatchState();
         await this.modalController.dismiss();
+    }
+
+    get failedCount(): number {
+        return this.batchItems.filter((item) => item.uploadStatus === 'failed').length;
+    }
+
+    get hasBatchPendingUploads(): boolean {
+        return this.batchItems.some((item) => item.uploadStatus === 'ready' || item.uploadStatus === 'failed');
+    }
+
+    trackByItemId(index: number, item: UploadReviewItem): string {
+        return item.id;
+    }
+
+    private validateSelection(files: File[]): { validFiles: File[], messages: string[] } {
+        const messages: string[] = [];
+        const validFiles: File[] = [];
+
+        if (files.length > this.maxBatchFiles) {
+            messages.push(`You can upload up to ${this.maxBatchFiles} photos at once. Extra files were ignored.`);
+        }
+
+        const candidateFiles = files.slice(0, this.maxBatchFiles);
+
+        let rejectedTypeCount = 0;
+        let rejectedSizeCount = 0;
+
+        for (const file of candidateFiles) {
+            if (!this.isSupportedImageFile(file)) {
+                rejectedTypeCount++;
+                continue;
+            }
+
+            if (file.size > this.maxFileSizeBytes) {
+                rejectedSizeCount++;
+                continue;
+            }
+
+            validFiles.push(file);
+        }
+
+        if (rejectedTypeCount > 0) {
+            messages.push(`${rejectedTypeCount} file(s) were rejected because they are not valid image types.`);
+        }
+
+        if (rejectedSizeCount > 0) {
+            messages.push(`${rejectedSizeCount} file(s) were rejected because they exceed 12 MB.`);
+        }
+
+        return { validFiles, messages };
+    }
+
+    private isSupportedImageFile(file: File): boolean {
+        return !!file?.type && file.type.startsWith('image/');
+    }
+
+    private async activateSingleFile(file: File): Promise<void> {
+        this.cleanupBatchState();
+        this.cleanupSingleState(false);
+
+        this.singleSelectedFile = file;
+        this.singleRotationDeg = 0;
+        await this.refreshSinglePreview();
+    }
+
+    private activateBatchFiles(files: File[]): void {
+        this.cleanupSingleState();
+        this.cleanupBatchState();
+
+        this.batchItems = files.map((file, index) => ({
+            id: `${Date.now()}-${index}-${file.name}`,
+            file,
+            previewUrl: URL.createObjectURL(file),
+            comment: '',
+            rotationDeg: 0,
+            uploadStatus: 'ready',
+            processState: 'idle',
+            sizeBytes: file.size
+        }));
+
+        this.isBatchReviewOpen = true;
+    }
+
+    private async refreshSinglePreview(): Promise<void> {
+        if (!this.singleSelectedFile) {
+            this.imgData = null;
+            return;
+        }
+
+        this.imgData = await this.enqueueImageProcessing(() =>
+            this.processFileToJpegBase64(
+                this.singleSelectedFile as File,
+                this.singleRotationDeg,
+                this.maxImageLongEdgePx,
+                this.uploadJpegQuality
+            )
+        );
+    }
+
+    private async generateUploadDataForItem(item: UploadReviewItem): Promise<string> {
+        return this.enqueueImageProcessing(async () => {
+            const data = await this.processFileToJpegBase64(
+                item.file,
+                item.rotationDeg,
+                this.maxImageLongEdgePx,
+                this.uploadJpegQuality
+            );
+            return data;
+        });
+    }
+
+    private async generatePreviewUrlForItem(item: UploadReviewItem): Promise<string> {
+        const previewBlob = await this.enqueueImageProcessing(() =>
+            this.processFileToJpegBlob(item.file, item.rotationDeg, this.maxImageLongEdgePx, this.uploadJpegQuality)
+        );
+
+        return URL.createObjectURL(previewBlob);
+    }
+
+    private enqueueImageProcessing<T>(task: () => Promise<T>): Promise<T> {
+        const nextTask = this.processingQueue.then(task, task);
+        this.processingQueue = nextTask.then(() => undefined, () => undefined);
+        return nextTask;
+    }
+
+    private async processFileToJpegBase64(file: File, rotationDeg: 0 | 90 | 180 | 270, maxLongEdge: number, quality: number): Promise<string> {
+        const canvas = await this.renderFileToCanvas(file, rotationDeg, maxLongEdge);
+        return canvas.toDataURL('image/jpeg', quality);
+    }
+
+    private async processFileToJpegBlob(file: File, rotationDeg: 0 | 90 | 180 | 270, maxLongEdge: number, quality: number): Promise<Blob> {
+        const canvas = await this.renderFileToCanvas(file, rotationDeg, maxLongEdge);
+
+        return new Promise((resolve, reject) => {
+            canvas.toBlob((blob) => {
+                if (!blob) {
+                    reject(new Error('Could not generate preview blob'));
+                    return;
+                }
+                resolve(blob);
+            }, 'image/jpeg', quality);
+        });
+    }
+
+    private async renderFileToCanvas(file: File, rotationDeg: 0 | 90 | 180 | 270, maxLongEdge: number): Promise<HTMLCanvasElement> {
+        const image = await this.loadImageFromFile(file);
+        const canvas = this.processingCanvasRef.nativeElement;
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+            throw new Error('Image canvas unavailable');
+        }
+
+        const sourceWidth = image.naturalWidth || image.width;
+        const sourceHeight = image.naturalHeight || image.height;
+        const rotated = rotationDeg === 90 || rotationDeg === 270;
+        const rotatedWidth = rotated ? sourceHeight : sourceWidth;
+        const rotatedHeight = rotated ? sourceWidth : sourceHeight;
+        const scale = Math.min(1, maxLongEdge / Math.max(rotatedWidth, rotatedHeight));
+
+        canvas.width = Math.max(1, Math.round(rotatedWidth * scale));
+        canvas.height = Math.max(1, Math.round(rotatedHeight * scale));
+
+        ctx.save();
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        switch (rotationDeg) {
+            case 90:
+                ctx.translate(canvas.width, 0);
+                ctx.rotate(Math.PI / 2);
+                break;
+            case 180:
+                ctx.translate(canvas.width, canvas.height);
+                ctx.rotate(Math.PI);
+                break;
+            case 270:
+                ctx.translate(0, canvas.height);
+                ctx.rotate(-Math.PI / 2);
+                break;
+            default:
+                break;
+        }
+
+        const drawWidth = rotated ? canvas.height : canvas.width;
+        const drawHeight = rotated ? canvas.width : canvas.height;
+        ctx.drawImage(image, 0, 0, drawWidth, drawHeight);
+        ctx.restore();
+
+        return canvas;
+    }
+
+    private loadImageFromFile(file: File): Promise<HTMLImageElement> {
+        return new Promise((resolve, reject) => {
+            const url = URL.createObjectURL(file);
+            const img = new Image();
+
+            img.onload = () => {
+                URL.revokeObjectURL(url);
+                resolve(img);
+            };
+            img.onerror = () => {
+                URL.revokeObjectURL(url);
+                reject(new Error('Could not decode image'));
+            };
+
+            img.src = url;
+        });
+    }
+
+    private nextRotation(rotationDeg: 0 | 90 | 180 | 270): 0 | 90 | 180 | 270 {
+        const next = (rotationDeg + 90) % 360;
+        return next as 0 | 90 | 180 | 270;
+    }
+
+    private cleanupSingleState(resetComment: boolean = true): void {
+        this.imgData = null;
+        this.singleSelectedFile = null;
+        this.singleRotationDeg = 0;
+        if (resetComment) {
+            this.comment = '';
+        }
+    }
+
+    private cleanupBatchState(revokeUrls: boolean = true): void {
+        if (revokeUrls) {
+            for (const item of this.batchItems) {
+                URL.revokeObjectURL(item.previewUrl);
+            }
+        }
+        this.batchItems = [];
+        this.isBatchReviewOpen = false;
+        this.isBatchUploading = false;
+    }
+
+    private resetFileInput(): void {
+        const input = this.inputFileRef?.nativeElement;
+        if (input) {
+            input.value = '';
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR upgrades the media upload experience from a single-image flow to a hybrid single/batch flow with in-app review and client-side preprocessing before upload.

These changes were made to safely support multi-image uploads and to address:
https://github.com/openchargemap/ocm-app/issues/40

And its also related with this PR below :
https://github.com/openchargemap/ocm-system/pull/249


## What changed
- Added support for selecting multiple image files from the file picker (`accept="image/*"`, `multiple`).
- Replaced direct file-input click behavior with a dedicated action handler (`onChoosePhoto`) and centralized file-selection flow (`onFileSelectionChanged`).
- Introduced a batch review modal where users can:
  - preview selected images,
  - add per-image comments,
  - rotate individual images,
  - remove items before upload,
  - upload all pending items or retry failed items.
- Added batch state and upload lifecycle handling (`ready / uploading / uploaded / failed`) with retry support and failure messaging.
- Added validation for upload constraints:
  - max files per batch,
  - max file size,
  - image-only MIME types,
  - user toast notifications for rejected files.
- Refactored image processing to use a hidden canvas via `ViewChild`, including:
  - resize-to-max-long-edge,
  - JPEG quality compression,
  - 90° rotation transforms,
  - queueing to serialize image processing tasks.
- Updated single-image flow to remain supported while disabling footer upload when batch review is open to avoid conflicting actions.
- Added SCSS for batch thumbnail sizing, action row layout, and success/error status text styles.

## Impact
- Users can now upload multiple photos in one session with better control and feedback.
- Upload reliability improves through retry-on-failure for failed batch items.
- Client-side processing reduces payload size and normalizes orientation before submission.

## Notes
- Existing single-image upload behavior is preserved.
- Batch state cleanup revokes object URLs and resets input state on dismissal/cancel/destruction to reduce memory leaks.